### PR TITLE
added commands to stop any shell script on error and return fail code

### DIFF
--- a/src/evaluation/invivo_footprints/script_new.sh
+++ b/src/evaluation/invivo_footprints/script_new.sh
@@ -1,3 +1,11 @@
+# exit when any command fails
+set -e
+
+# keep track of the last executed command
+trap 'last_command=$current_command; current_command=$BASH_COMMAND' DEBUG
+# echo an error message before exiting
+trap 'echo "\"${last_command}\" command filed with exit code $?."' EXIT
+
 python tf_modiscohits.py --outdir=count/k562_hits/ \
 	/srv/scratch/anusri/chrombpnet_paper/results/chrombpnet_nov_08/ATAC/K562/4_4_shifted_ATAC_09.29.2021_bias_filters_500/final_model_step3/unplug/deepshap/20K.fold0.deepSHAP \
 	/oak/stanford/groups/akundaje/projects/chrombpnet_paper/modisco/flank_len_500/SIGNAL/K562/4_4_shifted_ATAC_09.29.2021_bias_filters_500_new/20K.fold0.deepSHAP.count_shap.hdf5 \

--- a/src/evaluation/modisco/run.sh
+++ b/src/evaluation/modisco/run.sh
@@ -1,4 +1,10 @@
+# exit when any command fails
+set -e
 
+# keep track of the last executed command
+trap 'last_command=$current_command; current_command=$BASH_COMMAND' DEBUG
+# echo an error message before exiting
+trap 'echo "\"${last_command}\" command filed with exit code $?."' EXIT
 
 
 scores_prefix=$1

--- a/src/helpers/make_gc_matched_negatives/run.sh
+++ b/src/helpers/make_gc_matched_negatives/run.sh
@@ -1,4 +1,11 @@
 #!/bin/bash
+# exit when any command fails
+set -e
+
+# keep track of the last executed command
+trap 'last_command=$current_command; current_command=$BASH_COMMAND' DEBUG
+# echo an error message before exiting
+trap 'echo "\"${last_command}\" command filed with exit code $?."' EXIT
 
 foreground_bed=$1
 exclude_bed=$2

--- a/src/helpers/preprocessing/bam_to_bigwig.sh
+++ b/src/helpers/preprocessing/bam_to_bigwig.sh
@@ -1,4 +1,11 @@
 #!/bin/bash
+# exit when any command fails
+set -e
+
+# keep track of the last executed command
+trap 'last_command=$current_command; current_command=$BASH_COMMAND' DEBUG
+# echo an error message before exiting
+trap 'echo "\"${last_command}\" command filed with exit code $?."' EXIT
 
 input_bam=$1
 output_prefix=$2

--- a/src/helpers/preprocessing/images/script.sh
+++ b/src/helpers/preprocessing/images/script.sh
@@ -1,4 +1,11 @@
 #!/bin/bash
+# exit when any command fails
+set -e
+
+# keep track of the last executed command
+trap 'last_command=$current_command; current_command=$BASH_COMMAND' DEBUG
+# echo an error message before exiting
+trap 'echo "\"${last_command}\" command filed with exit code $?."' EXIT
 
 # DNASE is SE data
 # ATAC is PE

--- a/step1_download_bams_and_peaks.sh
+++ b/step1_download_bams_and_peaks.sh
@@ -1,3 +1,9 @@
+# exit when any command fails
+set -e
+# keep track of the last executed command
+trap 'last_command=$current_command; current_command=$BASH_COMMAND' DEBUG
+# echo an error message before exiting
+trap 'echo "\"${last_command}\" command filed with exit code $?."' EXIT
 data_dir=$1
 
 # download bam

--- a/step2_make_bigwigs_from_bams.sh
+++ b/step2_make_bigwigs_from_bams.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+# exit when any command fails
+set -e
+
+# keep track of the last executed command
+trap 'last_command=$current_command; current_command=$BASH_COMMAND' DEBUG
+# echo an error message before exiting
+trap 'echo "\"${last_command}\" command filed with exit code $?."' EXIT
+
 in_bam=$1
 bigwig_prefix=$2
 data_type=$3

--- a/step3_get_background_regions.sh
+++ b/step3_get_background_regions.sh
@@ -1,4 +1,11 @@
 #!/bin/bash
+# exit when any command fails
+set -e
+
+# keep track of the last executed command
+trap 'last_command=$current_command; current_command=$BASH_COMMAND' DEBUG
+# echo an error message before exiting
+trap 'echo "\"${last_command}\" command filed with exit code $?."' EXIT
 
 reference_fasta=$1
 chrom_sizes=$2

--- a/step4_train_bias_model.sh
+++ b/step4_train_bias_model.sh
@@ -1,3 +1,10 @@
+# exit when any command fails
+set -e
+
+# keep track of the last executed command
+trap 'last_command=$current_command; current_command=$BASH_COMMAND' DEBUG
+# echo an error message before exiting
+trap 'echo "\"${last_command}\" command filed with exit code $?."' EXIT
 
 reference_fasta=$1
 bigwig_path=$2

--- a/step5_interpret_bias_model.sh
+++ b/step5_interpret_bias_model.sh
@@ -1,3 +1,10 @@
+# exit when any command fails
+set -e
+
+# keep track of the last executed command
+trap 'last_command=$current_command; current_command=$BASH_COMMAND' DEBUG
+# echo an error message before exiting
+trap 'echo "\"${last_command}\" command filed with exit code $?."' EXIT
 reference_fasta=$1
 regions=$2
 model_h5=$3

--- a/step6_train_chrombpnet_model.sh
+++ b/step6_train_chrombpnet_model.sh
@@ -1,3 +1,11 @@
+# exit when any command fails
+set -e
+
+# keep track of the last executed command
+trap 'last_command=$current_command; current_command=$BASH_COMMAND' DEBUG
+# echo an error message before exiting
+trap 'echo "\"${last_command}\" command filed with exit code $?."' EXIT
+
 reference_fasta=$1
 bigwig_path=$2
 overlap_peak=$3

--- a/step7_interpret_chrombpnet_model.sh
+++ b/step7_interpret_chrombpnet_model.sh
@@ -1,3 +1,11 @@
+# exit when any command fails
+set -e
+
+# keep track of the last executed command
+trap 'last_command=$current_command; current_command=$BASH_COMMAND' DEBUG
+# echo an error message before exiting
+trap 'echo "\"${last_command}\" command filed with exit code $?."' EXIT
+
 reference_fasta=$1
 regions=$2
 model_h5=$3


### PR DESCRIPTION
Many shell scripts within the repo execute multiple commands. If one command fails, the script will keep running the other commands, which is suboptimal as those generally rely on the output of the failed command. Added code to stop script on failure of any command and return which command failed and with which error code. 
