### PR TITLE
option to provide ylim for marging footprint plotting

### DIFF
--- a/src/evaluation/marginal_footprints/README.md
+++ b/src/evaluation/marginal_footprints/README.md
@@ -5,7 +5,7 @@ The scripts in this folder provide marginal footprints for a given motif and bac
 ## Usage
 
 ```
-python marginal_footprinting.py -g [genome_fasta] -r [regions] -chr [test_chr] -m [model_h5] -bs [batch_size] -o [output_prefix] -pwm_f [motifs_to_pwm_file] -mo [motifs]
+python marginal_footprinting.py -g [genome_fasta] -r [regions] -chr [test_chr] -m [model_h5] -bs [batch_size] -o [output_prefix] -pwm_f [motifs_to_pwm_file] -mo [motifs] --ylim (min-y, max-y)
 ```
 
 ## Example Usage
@@ -24,7 +24,7 @@ python marginal_footprinting.py -g /path/to/genome_fasta -r /path/to/bed_file -c
 - output_prefix: Output prefix path and name to use. See Output format section below to understand how this is used.
 - motifs_to_pwm_file: Path to a TSV file containing motifs in first column (e.g. `Tn5`) and motif string (e.g. `GCACAGTACAGAGCTG`) to use for footprinting in second column. 
 - motifs: The motifs to filter from `motifs_to_pwm_file` for footprinting. We will find footprints only for the motifs mentioned here. Make sure that the motif names mentioned here are present in the column 1 of `motifs_to_pwm_file`. Provide more than one motif - seperate them by comma.
-
+--ylim: optional argument to specify the lower and upper y-axis values for the generated plot. This is a tuple of float/int values (lower y-lim bound for plotting, upper-ylim bound for plotting). Default is to not use this argument and auto-calculate the y-axis range.
 
 ## Output Format
 

--- a/src/evaluation/marginal_footprints/marginal_footprinting.py
+++ b/src/evaluation/marginal_footprints/marginal_footprinting.py
@@ -32,7 +32,8 @@ def fetch_footprinting_args():
                         help="Path to a TSV file containing motifs in first column and motif string to use for footprinting in second column")    
     parser.add_argument("-mo", "--motifs", nargs="+", type=lambda s: [str(item.strip()) for item in s.split(',')], default=["Tn5"],
                         help="Input motifs to do marginal footprinting, the motif names input here should be present in the collumn one in motifs_to_pwm file argument")
-    parser.add_argument("--ylim",default=(0,0.08),type=tuple, required=False,help="lower and upper y-limits for plotting the motif footprint")
+    parser.add_argument("--ylim",default=None,type=tuple, required=False,help="lower and upper y-limits for plotting the motif footprint, in the form of a tuple i.e. \
+    (0,0.8). If this is set to None, ylim will be autodetermined.")
     
     args = parser.parse_args()
     return args
@@ -103,7 +104,8 @@ def main():
                 avg_response_at_tn5.append(np.round(np.max(motif_footprint[outputlen//2-100:outputlen//2+100]),3))
         plt.figure()
         plt.plot(range(200),motif_footprint[outputlen//2-100:outputlen//2+100])
-        plt.ylim(args.ylim)
+        if args.ylim is not None: 
+            plt.ylim(args.ylim)
         plt.savefig(args.output_prefix+".{}.footprint.png".format(motif))
 
     if np.mean(avg_response_at_tn5) < 0.006:

--- a/src/evaluation/marginal_footprints/marginal_footprinting.py
+++ b/src/evaluation/marginal_footprints/marginal_footprinting.py
@@ -32,6 +32,7 @@ def fetch_footprinting_args():
                         help="Path to a TSV file containing motifs in first column and motif string to use for footprinting in second column")    
     parser.add_argument("-mo", "--motifs", nargs="+", type=lambda s: [str(item.strip()) for item in s.split(',')], default=["Tn5"],
                         help="Input motifs to do marginal footprinting, the motif names input here should be present in the collumn one in motifs_to_pwm file argument")
+    parser.add_argument("--ylim",default=(0,0.08),type=tuple, required=False,help="lower and upper y-limits for plotting the motif footprint")
     
     args = parser.parse_args()
     return args
@@ -102,6 +103,7 @@ def main():
                 avg_response_at_tn5.append(np.round(np.max(motif_footprint[outputlen//2-100:outputlen//2+100]),3))
         plt.figure()
         plt.plot(range(200),motif_footprint[outputlen//2-100:outputlen//2+100])
+        plt.ylim(args.ylim)
         plt.savefig(args.output_prefix+".{}.footprint.png".format(motif))
 
     if np.mean(avg_response_at_tn5) < 0.006:


### PR DESCRIPTION
helpful to plot multiple marginal footprints on fixed scale. 
Pr sets default scale (0,0.08) with option to pass alternate --ylim arg to marginal_footprinting script. 
