### PR TITLE
Faster genomewide gc counting

### DIFF
--- a/src/helpers/make_gc_matched_negatives/get_genomewide_gc_buckets/README.md
+++ b/src/helpers/make_gc_matched_negatives/get_genomewide_gc_buckets/README.md
@@ -17,5 +17,13 @@ The above scripts bins the genome into `inputlen` length regions. The bin interv
 
 ### Output format:
 
-The script outputs a tab-seperated file containing chr, start, end and gc_content. These are genome wide regions binned into `inputlen` regions and with a given `stride`. 
-For example look at the following pre-generated file at http://mitra.stanford.edu/kundaje/anusri/chrombpnet_downloads/genomewide_gc_hg38_stride_1000_inputlen_2114.bed generated with `inputlen` 2114 and `stride` 1000 using this script.
+The script outputs a tab-seperated file containing chr, start, end and gc_content. These are genome wide regions binned into `inputlen` regions and with a given `stride`.
+
+Genomewide bins for hg38 using source file https://www.encodeproject.org/files/GRCh38_no_alt_analysis_set_GCA_000001405.15/@@download/GRCh38_no_alt_analysis_set_GCA_000001405.15.fasta.gz have been generated
+at  http://mitra.stanford.edu/kundaje/anusri/chrombpnet_downloads/genomewide_gc_hg38_stride_1000_inputlen_2114.bed generated with `inputlen` 2114 and `stride` 1000 using this script.
+
+```
+wget https://www.encodeproject.org/files/GRCh38_no_alt_analysis_set_GCA_000001405.15/@@download/GRCh38_no_alt_analysis_set_GCA_000001405.15.fasta.gz
+gzip -d GRCh38_no_alt_analysis_set_GCA_000001405.15.fasta.gz
+python get_genomewide_gc_bins.py -g GRCh38_no_alt_analysis_set_GCA_000001405.15.fasta -o genomewide_gc_hg38_stride_1000_inputlen_2114.bed -f 2114 -s 1000
+```

--- a/src/helpers/make_gc_matched_negatives/get_genomewide_gc_buckets/README.md
+++ b/src/helpers/make_gc_matched_negatives/get_genomewide_gc_buckets/README.md
@@ -3,7 +3,7 @@ Scripts to find the gc content of genome wide bins.
 ### Usage
 
 ```bash 
-python get_genomewide_gc_bins.py -g [genome] -o [output_path]  -f [inputlen] -s [stride]
+python get_genomewide_gc_bins.py -g [genome] -o [output_prefix]  -f [inputlen] -s [stride]
 ```
 
 The above scripts bins the genome into `inputlen` length regions. The bin intervals are spaced at `stride` length.
@@ -11,7 +11,7 @@ The above scripts bins the genome into `inputlen` length regions. The bin interv
 ### Input format:
 
 - genome: Reference geneome fasta.
-- output_path: Path and file name to store the output. See output format section below.
+- output_prefix: Output path prefix to store the output, ".bed" is appended as suffix by the code. If path conatins a directory make sure it already exists. See output format section below.
 - inputlen: An integer value for the length of a bin for gc-fraction calculation.
 - stride: An integer stride value to space the bins.
 
@@ -25,5 +25,5 @@ at  http://mitra.stanford.edu/kundaje/anusri/chrombpnet_downloads/genomewide_gc_
 ```
 wget https://www.encodeproject.org/files/GRCh38_no_alt_analysis_set_GCA_000001405.15/@@download/GRCh38_no_alt_analysis_set_GCA_000001405.15.fasta.gz
 gzip -d GRCh38_no_alt_analysis_set_GCA_000001405.15.fasta.gz
-python get_genomewide_gc_bins.py -g GRCh38_no_alt_analysis_set_GCA_000001405.15.fasta -o genomewide_gc_hg38_stride_1000_inputlen_2114.bed -f 2114 -s 1000
+python get_genomewide_gc_bins.py -g GRCh38_no_alt_analysis_set_GCA_000001405.15.fasta -o genomewide_gc_hg38_stride_1000_inputlen_2114 -f 2114 -s 1000
 ```

--- a/src/helpers/make_gc_matched_negatives/get_genomewide_gc_buckets/get_genomewide_gc_bins.py
+++ b/src/helpers/make_gc_matched_negatives/get_genomewide_gc_buckets/get_genomewide_gc_bins.py
@@ -4,7 +4,7 @@ import argparse
 def parse_args():
     parser=argparse.ArgumentParser(description="get gc content after binning the entire genome into bins")
     parser.add_argument("-g","--genome", required=True, help="reference genome file")
-    parser.add_argument("-o","--output_bed", required=True, help="output BED file to store the gc content of binned genome")
+    parser.add_argument("-o","--output_prefix", required=True, help="output BED file prefix to store the gc content of binned genome. suffix .bed will be appended by the code. If the prefix contains a directory path make sure it exists.")
     parser.add_argument("-f","--inputlen", type=int,default=2114, help="inputlen to use to find gc content")
     parser.add_argument("-s","--stride", type=int,default=1000, help="stride to use for shifting the bins")
     return parser.parse_args()
@@ -71,4 +71,4 @@ def get_genomewide_gc(genome_fa, outf, width, stride):
 
 if __name__=="__main__":
     args = parse_args()
-    get_genomewide_gc(args.genome, args.output_bed, args.inputlen, args.stride)
+    get_genomewide_gc(args.genome, args.output_prefix+".bed", args.inputlen, args.stride)

--- a/src/helpers/make_gc_matched_negatives/get_genomewide_gc_buckets/get_genomewide_gc_bins.py
+++ b/src/helpers/make_gc_matched_negatives/get_genomewide_gc_buckets/get_genomewide_gc_bins.py
@@ -55,7 +55,7 @@ def get_genomewide_gc(genome_fa, outf, width, stride):
                 left_ct = s.count("C", i, i+rem) + s.count("G", i, i+rem)
                 runsum += left_ct
 
-            outf.write("{}\t{}\t{}\t{:.2f}\n".format(chrm, i - stride_x_div, i - stride_x_div + width, runsum/width))
+            outf.write("{}\t{}\t{}\t{}\n".format(chrm, i - stride_x_div, i - stride_x_div + width, round(runsum/width,2)))
 
             if div == 0: # stride > width, do no more
                 runsum = 0

--- a/src/helpers/make_gc_matched_negatives/get_genomewide_gc_buckets/get_genomewide_gc_bins.py
+++ b/src/helpers/make_gc_matched_negatives/get_genomewide_gc_buckets/get_genomewide_gc_bins.py
@@ -3,8 +3,8 @@ import argparse
 
 def parse_args():
     parser=argparse.ArgumentParser(description="get gc content after binning the entire genome into bins")
-    parser.add_argument("-g","--genome", help="reference genome file")
-    parser.add_argument("-o","--output_bed", help="output BED file to store the gc content of binned genome")
+    parser.add_argument("-g","--genome", required=True, help="reference genome file")
+    parser.add_argument("-o","--output_bed", required=True, help="output BED file to store the gc content of binned genome")
     parser.add_argument("-f","--inputlen", type=int,default=2114, help="inputlen to use to find gc content")
     parser.add_argument("-s","--stride", type=int,default=1000, help="stride to use for shifting the bins")
     return parser.parse_args()

--- a/tests/genomewide_gc_bin_test.sh
+++ b/tests/genomewide_gc_bin_test.sh
@@ -13,9 +13,9 @@ do
 done
 
 #assert we get the expectd md5sum values
-#2911f95c85673d86cff8daa4eaca5250  100.chr21.gc.bed
-#0bec3a55b97a2fa1a4f62e5abb375653  1000.chr21.gc.bed
-#43c3d7185c4748532b36959f3c0ca346  500.chr21.gc.bed
+expected_md5sum_100="1c49d5ff0f5b8e8c09d38360fc50561c"
+expected_md5sum_500="f99b40005b496a8f4f7fa9ca04e89bb4"
+expected_md5sum_1000="b1c5b8157ff49a9365f0dd6c628afc98"
 
 #get md5sum values for the genomewide gc content
 md5sum_100=($(md5sum 100.chr21.gc.bed))
@@ -25,27 +25,27 @@ echo $md5sum_100
 echo $md5sum_500
 echo $md5sum_1000
 
-if [ $md5sum_100 = "2911f95c85673d86cff8daa4eaca5250" ]; 
+if [ $md5sum_100 = $expected_md5sum_100 ]; 
 then
     echo "obtained expected md5sum for 100.chr21.gc.bed"
 else
-    echo "md5sum $md5sum_100 does not match expected value 2911f95c85673d86cff8daa4eaca5250"
+    echo "md5sum $md5sum_100 does not match expected value $expected_md5sum_100"
     exit 1
 fi
 
-if [ $md5sum_500 = "43c3d7185c4748532b36959f3c0ca346" ];
+if [ $md5sum_500 = $expected_md5sum_500 ];
 then
     echo "obtained expected md5sum for 500.chr21.gc.bed"
 else
-    echo "md5sum $md5sum_500 does not match expected value 43c3d7185c4748532b36959f3c0ca346"
+    echo "md5sum $md5sum_500 does not match expected value $expected_md5sum_500"
     exit 1
 fi
 
-if [ $md5sum_1000 = "0bec3a55b97a2fa1a4f62e5abb375653" ]; 
+if [ $md5sum_1000 = $expected_md5sum_1000 ]; 
 then
-    echo "obtained expected md5sum for 100.chr21.gc.bed"
+    echo "obtained expected md5sum for 1000.chr21.gc.bed"
 else
-    echo "md5sum $md5sum_100 does not match expected value 0bec3a55b97a2fa1a4f62e5abb375653"
+    echo "md5sum $md5sum_100 does not match expected value $expected_md5sum_1000"
     exit 1
 fi
 

--- a/tests/genomewide_gc_bin_test.sh
+++ b/tests/genomewide_gc_bin_test.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+#pull down chr21 of hg38 for test
+wget -O chr21.fa.gz https://hgdownload.cse.ucsc.edu/goldenPath/hg38/chromosomes/chr21.fa.gz 
+gzip -df chr21.fa.gz
+echo "downloaded chr21 hg38 fasta file" 
+
+#test for several strides
+for stride in 100 500 1000
+do
+    echo $stride 
+    python ../src/helpers/make_gc_matched_negatives/get_genomewide_gc_buckets/get_genomewide_gc_bins.py -g chr21.fa -o $stride.chr21.gc.bed -f 2114 -s $stride 
+done
+
+#assert we get the expectd md5sum values
+#2911f95c85673d86cff8daa4eaca5250  100.chr21.gc.bed
+#0bec3a55b97a2fa1a4f62e5abb375653  1000.chr21.gc.bed
+#43c3d7185c4748532b36959f3c0ca346  500.chr21.gc.bed
+
+#get md5sum values for the genomewide gc content
+md5sum_100=($(md5sum 100.chr21.gc.bed))
+md5sum_500=($(md5sum 500.chr21.gc.bed))
+md5sum_1000=($(md5sum 1000.chr21.gc.bed))
+echo $md5sum_100
+echo $md5sum_500
+echo $md5sum_1000
+
+if [ $md5sum_100 = "2911f95c85673d86cff8daa4eaca5250" ]; 
+then
+    echo "obtained expected md5sum for 100.chr21.gc.bed"
+else
+    echo "md5sum $md5sum_100 does not match expected value 2911f95c85673d86cff8daa4eaca5250"
+    exit 1
+fi
+
+if [ $md5sum_500 = "43c3d7185c4748532b36959f3c0ca346" ];
+then
+    echo "obtained expected md5sum for 500.chr21.gc.bed"
+else
+    echo "md5sum $md5sum_500 does not match expected value 43c3d7185c4748532b36959f3c0ca346"
+    exit 1
+fi
+
+if [ $md5sum_1000 = "0bec3a55b97a2fa1a4f62e5abb375653" ]; 
+then
+    echo "obtained expected md5sum for 100.chr21.gc.bed"
+else
+    echo "md5sum $md5sum_100 does not match expected value 0bec3a55b97a2fa1a4f62e5abb375653"
+    exit 1
+fi
+
+


### PR DESCRIPTION
Get GC fraction in bins of width "width" strided by "stride".

Main speedups come from:
- loading entire chromosome string using pyfaidx
- using the str.count function for substrings
- avoiding redundant counting

Redundant counting is avoided by counting in bins of size "stride" at a time and caching the most recent values in `cache`. As an example:

For width 2114 and stride 1000, when considering the 3000-4000 bin, with already cached counts in 1000-2000 and 2000-3000, count in 3000-3114 and write 1000-3114. Then count in 3114-4000, now cache 3000-4000 and delete 1000-2000. And repeat.