### PR TITLE
change github workflow to avoid overwriting dev docker; update dockerfile to deal with deprecated keys & commands that prevent a proper build 

### DIFF
--- a/.github/workflows/latest-docker-image.yml
+++ b/.github/workflows/latest-docker-image.yml
@@ -21,7 +21,8 @@ jobs:
               
     - name: Build the Docker image
 
-      run: docker build . --file dockerfile --tag kundajelab/chrombpnet:dev
+      run: docker build . --file dockerfile --tag kundajelab/chrombpnet:latest
       
     - name: Docker Push
-      run: docker push kundajelab/chrombpnet:dev
+      run: docker push kundajelab/chrombpnet:latest
+      

--- a/dockerfile
+++ b/dockerfile
@@ -1,6 +1,10 @@
 # Use the official TensorFlow image as parent
 FROM tensorflow/tensorflow:2.4.1-gpu
 
+#key signing issue with cuda repo can be fixed by removing from apt sources and re-adding in apt-get update 
+RUN rm /etc/apt/sources.list.d/cuda.list
+RUN rm /etc/apt/sources.list.d/nvidia-ml.list
+
 # Set the working directory
 WORKDIR /scratch
 
@@ -37,7 +41,7 @@ RUN apt-get install -y jq
 
 # Clean up after apt and conda
 RUN apt-get clean && rm -rf /var/lib/apt/lists/*
-RUN conda clean -tipsy
+RUN conda clean -tipy
 
 # Set environment variables for Python
 ENV LC_ALL=C.UTF-8


### PR DESCRIPTION
* changed github action workflow to tag the master version with 'latest' tag, as dev tag should be considered frozen for future purposes and this prevents any accidental overwrites; 

* modified dockerfile to reflect updates in conda parameters (-s deprecated) and to address cuda repo signing issue in apt