### PR TITLE
Removed warning message from init

### DIFF
--- a/chrombpnet/__init__.py
+++ b/chrombpnet/__init__.py
@@ -1,2 +1,2 @@
-print("WARNING: IF upgrading from v1.0 or v1.1 to v1.2, note that chrombpnet has undergone linting to generate a modular structure for release on pypi."
-      "Hard-coded script paths are no longer necessary. Please refer to the updated README to ensure your script calls are compatible with v1.2")
+#print("WARNING: IF upgrading from v1.0 or v1.1 to v1.2, note that chrombpnet has undergone linting to generate a modular structure for release on pypi."
+#      "Hard-coded script paths are no longer necessary. Please refer to the updated README to ensure your script calls are compatible with v1.2")


### PR DESCRIPTION
Removes the warning from __init__.py. This fixes the error where the warning gets printed when trying to get the package directory from chrombpnet.get_package_dir:main, which is used via chrombpnet_srcdir in the Step 6 script for running chrombpnet_marginal_footprints. One way to see the problem is to simply run the command: chrombpnet_srcdir