### PR TITLE
dockerfile modified to update pip; pip install chrombpnet

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -50,7 +50,14 @@ ENV LANG=C.UTF-8
 RUN mkdir /scratch/chrombpnet
 COPY . /scratch/chrombpnet
 
+# need to upgrade pip for faster dependency resolution
+RUN pip install --upgrade pip 
+
 # Install any needed packages specified in requirements.txt
 RUN pip install -r /scratch/chrombpnet/requirements.txt
+
+#Install chrombpnet itself
+WORKDIR /scratch
+RUN pip install -e chrombpnet
 
 


### PR DESCRIPTION
This PR updates pip to the latest version (older pip is slow to resolve dependencies) and runs pip install -e in the docker image -- this was not needed in releases v1.0 or v1.1, but is needed for releases v1.2 and up, since chrombpnet was converted to pip package. 