### PR TITLE
updated sklearn to 1.1.2 to incorporate perplexity check for n_samples in tSNE

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ matplotlib-venn==0.11.6
 numpy>=1.20
 pandas>=1.3.4
 pyfaidx==0.6.1
-scikit-learn>=0.23.2
+scikit-learn>=1.1.2
 scipy>=1.4.1
 tensorflow-gpu==2.8.0 
 tensorflow-estimator==2.8.0 


### PR DESCRIPTION
sklearn 1.1.2 has this commit added: https://github.com/scikit-learn/scikit-learn/commit/b54a5289d5090346093ec36dc117ec2a72420563

This throws an error in tSNE if perplexity < n_samples, which will cause an error if we try to run tSNE in modisco on cluster with < 50 seqlets (perplexity hard-coded to 50) 
