### PR TITLE
successful execution message on exit code 0

### DIFF
--- a/chrombpnet/evaluation/modisco/modisco.sh
+++ b/chrombpnet/evaluation/modisco/modisco.sh
@@ -5,9 +5,19 @@ set -e
 
 # keep track of the last executed command
 trap 'last_command=$current_command; current_command=$BASH_COMMAND' DEBUG
-# echo an error message before exiting
-trap 'echo "\"${last_command}\" command filed with exit code $?."' EXIT
 
+cleanup() {
+    exit_code=$?
+    if [ ${exit_code} == 0 ]
+    then
+	echo "Completed execution"
+    else
+	echo "\"${last_command}\" failed with exit code ${exit_code}."
+    fi
+}
+
+# echo an error message before exiting
+trap 'cleanup' EXIT INT TERM
 
 scores_prefix=${1?param missing - scores_prefix}
 output_dir=${2?param missing - output_dir}

--- a/chrombpnet/helpers/make_gc_matched_negatives/make_gc_matched_negatives.sh
+++ b/chrombpnet/helpers/make_gc_matched_negatives/make_gc_matched_negatives.sh
@@ -1,11 +1,23 @@
 #!/bin/bash
+
 # exit when any command fails
 set -e
 
 # keep track of the last executed command
 trap 'last_command=$current_command; current_command=$BASH_COMMAND' DEBUG
+
+cleanup() {
+    exit_code=$?
+    if [ ${exit_code} == 0 ]
+    then
+	echo "Completed execution"
+    else
+	echo "\"${last_command}\" failed with exit code ${exit_code}."
+    fi
+}
+
 # echo an error message before exiting
-trap 'echo "\"${last_command}\" command filed with exit code $?."' EXIT
+trap 'cleanup' EXIT INT TERM
 
 foreground_bed=${1?param missing - foreground_bed}
 exclude_bed=${2?param missing - exclude_bed}

--- a/chrombpnet/helpers/preprocessing/bam_to_bigwig.sh
+++ b/chrombpnet/helpers/preprocessing/bam_to_bigwig.sh
@@ -1,11 +1,24 @@
 #!/bin/bash
+
 # exit when any command fails
 set -e
 
 # keep track of the last executed command
 trap 'last_command=$current_command; current_command=$BASH_COMMAND' DEBUG
+
+cleanup() {
+    exit_code=$?
+    if [ ${exit_code} == 0 ]
+    then
+	echo "Completed execution"
+    else
+	echo "\"${last_command}\" failed with exit code ${exit_code}."
+    fi
+}
+
 # echo an error message before exiting
-trap 'echo "\"${last_command}\" command filed with exit code $?."' EXIT
+trap 'cleanup' EXIT INT TERM
+
 
 input_bam=${1?param missing - input_bam}
 output_prefix=${2?param missing - output_prefix}

--- a/step1_download_bams_and_peaks.sh
+++ b/step1_download_bams_and_peaks.sh
@@ -2,15 +2,29 @@
 
 echo "WARNING: If upgrading from v1.0 or v1.1 to v1.2. Note that chrombpnet has undergone linting to generate a modular structure for release on pypi.Hard-coded script paths are no longer necessary. Please refer to the updated README (below) to ensure your script calls are compatible with v1.2"
 
-
 # exit when any command fails
 set -e
-set -o pipefail
+
 # keep track of the last executed command
 trap 'last_command=$current_command; current_command=$BASH_COMMAND' DEBUG
+
+cleanup() {
+    exit_code=$?
+    if [ ${exit_code} == 0 ]
+    then
+	echo "Completed execution"
+    else
+	echo "\"${last_command}\" failed with exit code ${exit_code}."
+    fi
+}
+
 # echo an error message before exiting
-trap 'echo "\"${last_command}\" command failed with exit code $?."' EXIT
+trap 'cleanup' EXIT INT TERM
+
 data_dir=${1?param missing - data_dir}
+if [[ ! -e $data_dir ]]; then
+    mkdir $data_dir
+fi
 
 # download bam
 wget https://www.encodeproject.org/files/ENCFF077FBI/@@download/ENCFF077FBI.bam -O $data_dir/rep1.bam

--- a/step2_make_bigwigs_from_bams.sh
+++ b/step2_make_bigwigs_from_bams.sh
@@ -4,12 +4,22 @@ echo "WARNING: If upgrading from v1.0 or v1.1 to v1.2. Note that chrombpnet has 
 
 # exit when any command fails
 set -e
-set -o pipefail
 
 # keep track of the last executed command
 trap 'last_command=$current_command; current_command=$BASH_COMMAND' DEBUG
+
+cleanup() {
+    exit_code=$?
+    if [ ${exit_code} == 0 ]
+    then
+	echo "Completed execution"
+    else
+	echo "\"${last_command}\" failed with exit code ${exit_code}."
+    fi
+}
+
 # echo an error message before exiting
-trap 'echo "\"${last_command}\" command failed with exit code $?."' EXIT
+trap 'cleanup' EXIT INT TERM
 
 in_bam=${1?param missing - in_bam}
 bigwig_prefix=${2?param missing - bigwig_prefix}

--- a/step3_get_background_regions.sh
+++ b/step3_get_background_regions.sh
@@ -2,14 +2,26 @@
 
 echo "WARNING: If upgrading from v1.0 or v1.1 to v1.2. Note that chrombpnet has undergone linting to generate a modular structure for release on pypi.Hard-coded script paths are no longer necessary. Please refer to the updated README (below) to ensure your script calls are compatible with v1.2"
 
+
 # exit when any command fails
 set -e
-set -o pipefail
 
 # keep track of the last executed command
 trap 'last_command=$current_command; current_command=$BASH_COMMAND' DEBUG
+
+cleanup() {
+    exit_code=$?
+    if [ ${exit_code} == 0 ]
+    then
+	echo "Completed execution"
+    else
+	echo "\"${last_command}\" failed with exit code ${exit_code}."
+    fi
+}
+
 # echo an error message before exiting
-trap 'echo "\"${last_command}\" command failed with exit code $?."' EXIT
+trap 'cleanup' EXIT INT TERM
+
 
 reference_fasta=${1?param missing - reference_fasta}
 chrom_sizes=${2?param missing - chrom_sizes}
@@ -19,6 +31,11 @@ inputlen=${5?param missing - inputlen}
 genomewide_gc=${6?param missing - genomewide_gc}
 output_dir=${7?param missing - output_dir} 
 fold=${8?param missing - fold}
+
+if [[ ! -e $output_dir ]]; then
+    mkdir $output_dir
+fi
+
 
 function timestamp {
     # Function to get the current time with the new line character

--- a/step4_train_bias_model.sh
+++ b/step4_train_bias_model.sh
@@ -4,12 +4,22 @@ echo "WARNING: If upgrading from v1.0 or v1.1 to v1.2. Note that chrombpnet has 
 
 # exit when any command fails
 set -e
-set -o pipefail
 
 # keep track of the last executed command
 trap 'last_command=$current_command; current_command=$BASH_COMMAND' DEBUG
+
+cleanup() {
+    exit_code=$?
+    if [ ${exit_code} == 0 ]
+    then
+	echo "Completed execution"
+    else
+	echo "\"${last_command}\" failed with exit code ${exit_code}."
+    fi
+}
+
 # echo an error message before exiting
-trap 'echo "\"${last_command}\" command failed with exit code $?."' EXIT
+trap 'cleanup' EXIT INT TERM
 
 reference_fasta=${1?param missing - reference_fasta}
 bigwig_path=${2?param missing - bigwig_path}
@@ -22,6 +32,11 @@ filters=${8:-128}
 n_dilation_layers=${9:-4}
 seed=${10:-1234}
 logfile=${11}
+
+if [[ ! -e $output_dir ]]; then
+    mkdir $output_dir
+fi
+
 
 # defaults
 inputlen=2114

--- a/step5_interpret_bias_model.sh
+++ b/step5_interpret_bias_model.sh
@@ -2,14 +2,27 @@
 
 echo "WARNING: If upgrading from v1.0 or v1.1 to v1.2. Note that chrombpnet has undergone linting to generate a modular structure for release on pypi.Hard-coded script paths are no longer necessary. Please refer to the updated README (below) to ensure your script calls are compatible with v1.2"
 
+echo "WARNING: If upgrading from v1.0 or v1.1 to v1.2. Note that chrombpnet has undergone linting to generate a modular structure for release on pypi.Hard-coded script paths are no longer necessary. Please refer to the updated README (below) to ensure your script calls are compatible with v1.2"
+
 # exit when any command fails
 set -e
-set -o pipefail
 
 # keep track of the last executed command
 trap 'last_command=$current_command; current_command=$BASH_COMMAND' DEBUG
+
+cleanup() {
+    exit_code=$?
+    if [ ${exit_code} == 0 ]
+    then
+	echo "Completed execution"
+    else
+	echo "\"${last_command}\" failed with exit code ${exit_code}."
+    fi
+}
+
 # echo an error message before exiting
-trap 'echo "\"${last_command}\" command failed with exit code $?."' EXIT
+trap 'cleanup' EXIT INT TERM
+
 reference_fasta=${1?param missing - reference_fasta}
 regions=${2?param missing - regions}
 model_h5=${3?param missing - model_h5}

--- a/step6_train_chrombpnet_model.sh
+++ b/step6_train_chrombpnet_model.sh
@@ -4,12 +4,22 @@ echo "WARNING: If upgrading from v1.0 or v1.1 to v1.2. Note that chrombpnet has 
 
 # exit when any command fails
 set -e
-set -o pipefail
 
 # keep track of the last executed command
 trap 'last_command=$current_command; current_command=$BASH_COMMAND' DEBUG
+
+cleanup() {
+    exit_code=$?
+    if [ ${exit_code} == 0 ]
+    then
+	echo "Completed execution"
+    else
+	echo "\"${last_command}\" failed with exit code ${exit_code}."
+    fi
+}
+
 # echo an error message before exiting
-trap 'echo "\"${last_command}\" command failed with exit code $?."' EXIT
+trap 'cleanup' EXIT INT TERM
 
 reference_fasta=${1?param missing - reference_fasta}
 bigwig_path=${2?param missing - bigwig_path }
@@ -22,6 +32,11 @@ data_type=${8?param missing - data_type}
 seed=${9:-1234}
 logfile=${11} #optional
 pwm_f=${10} #optional
+
+if [[ ! -e $output_dir ]]; then
+    mkdir $output_dir
+fi
+
 
 # defaults
 inputlen=2114

--- a/step7_interpret_chrombpnet_model.sh
+++ b/step7_interpret_chrombpnet_model.sh
@@ -4,17 +4,30 @@ echo "WARNING: If upgrading from v1.0 or v1.1 to v1.2. Note that chrombpnet has 
 
 # exit when any command fails
 set -e
-set -o pipefail
 
 # keep track of the last executed command
 trap 'last_command=$current_command; current_command=$BASH_COMMAND' DEBUG
+
+cleanup() {
+    exit_code=$?
+    if [ ${exit_code} == 0 ]
+    then
+	echo "Completed execution"
+    else
+	echo "\"${last_command}\" failed with exit code ${exit_code}."
+    fi
+}
+
 # echo an error message before exiting
-trap 'echo "\"${last_command}\" command failed with exit code $?."' EXIT
+trap 'cleanup' EXIT INT TERM
 
 reference_fasta=${1?param missing - reference_fasta}
 regions=${2?param missing - regions}
 model_h5=${3?param missing - model_h5}
 output_dir=${4?param missing - output_dir}
+if [[ ! -e $output_dir ]]; then
+    mkdir $output_dir
+fi
 
 ## deepshap run
 


### PR DESCRIPTION
* If exit code is non-zero (i.e. an error) indicate that script exited with error code. 
* If exit code is 0 (i.e. success) indicate that successful execution occured. 
This was tested via the following test script: 

```
(base) annashch@brahma:~/chrombpnet$ cat test_error_codes.sh
#!/bin/bash

echo "WARNING: If upgrading from v1.0 or v1.1 to v1.2. Note that chrombpnet has undergone linting to generate a modular structure for release on pypi.Hard-coded script paths are no longer necessary. Please refer to the updated README (below) to ensure your script calls are compatible with v1.2"

# exit when any command fails
set -e

# keep track of the last executed command
trap 'last_command=$current_command; current_command=$BASH_COMMAND' DEBUG

cleanup() {
    exit_code=$?
    if [ ${exit_code} == 0 ]
    then
	echo "Completed execution"
    else
	echo "\"${last_command}\" failed with exit code ${exit_code}."
    fi
}

# echo an error message before exiting
trap 'cleanup' EXIT INT TERM

data_dir=${1?param missing - data_dir}
echo "hi"
```

test missing argument (i.e. failure): 

```
(base) annashch@brahma:~/chrombpnet$ ./test_error_codes.sh
WARNING: If upgrading from v1.0 or v1.1 to v1.2. Note that chrombpnet has undergone linting to generate a modular structure for release on pypi.Hard-coded script paths are no longer necessary. Please refer to the updated README (below) to ensure your script calls are compatible with v1.2
./test_error_codes.sh: line 24: 1: param missing - data_dir
"data_dir=${1?param missing - data_dir}" failed with exit code 1.
```
Test successful execution: 

```
(base) annashch@brahma:~/chrombpnet$ ./test_error_codes.sh data_dir
WARNING: If upgrading from v1.0 or v1.1 to v1.2. Note that chrombpnet has undergone linting to generate a modular structure for release on pypi.Hard-coded script paths are no longer necessary. Please refer to the updated README (below) to ensure your script calls are compatible with v1.2
hi
Completed execution
```