### PR TITLE
Migrate from tensorflow-gpu to tensorflow

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ pandas>=1.3.4
 pyfaidx==0.6.1
 scikit-learn>=1.1.2
 scipy>=1.4.1
-tensorflow-gpu==2.8.0 
+tensorflow==2.8.0 
 tensorflow-estimator==2.8.0 
 tensorflow-probability==0.15.0
 protobuf==3.20


### PR DESCRIPTION
`tensorflow-gpu` has been removed as a package. The regular `tensorflow` package uses GPU as default.