### PR TITLE
Update CHROMBPNET.py

### DIFF
--- a/chrombpnet/CHROMBPNET.py
+++ b/chrombpnet/CHROMBPNET.py
@@ -173,7 +173,7 @@ def main():
 		print("Command not found")
 
 
-if __name__=="__main_-":
+if __name__=="__main__":
 	main()
 
     


### PR DESCRIPTION
There seems to be a typo in the syntax for "__main__" that prevents debugging triggering the pipeline from CHROMBNET.py with arguments passed through instead of triggering from the command line. This becomes most problematic when needing to explore exact source of pipeline errors to fix them. For example, without this fix the following fails to pass arguments to the pipeline correctly: python3 -m pdb CHROMBPNET.py prep nonpeaks -g $genome_fasta -p $clean_peaks -c $chrom_sizes_subset -fl $fold0_json -br $blacklist -o $prep_output_dir