### PR TITLE
added --multiGPU flag to run training and prediction on multiple gpus

### DIFF
--- a/chrombpnet/evaluation/interpret/input_utils.py
+++ b/chrombpnet/evaluation/interpret/input_utils.py
@@ -30,8 +30,11 @@ def get_seq(peaks_df, genome, width):
 def load_model_wrapper(args):
     # read .h5 model
     custom_objects={"multinomial_nll": losses.multinomial_nll, "tf": tf}    
-    get_custom_objects().update(custom_objects)    
-    model=load_model(args.model_h5,compile=False)
+    get_custom_objects().update(custom_objects)
+    # get the strategy for multiGPU
+    from chrombpnet.helpers.misc import get_strategy
+    with get_strategy(args).scope():
+        model=load_model(args.model_h5,compile=False)
     print("got the model")
     model.summary()
     return model

--- a/chrombpnet/evaluation/make_bigwigs/predict_to_bigwig.py
+++ b/chrombpnet/evaluation/make_bigwigs/predict_to_bigwig.py
@@ -112,11 +112,14 @@ def softmax(x, temp=1):
     norm_x = x - np.mean(x,axis=1, keepdims=True)
     return np.exp(temp*norm_x)/np.sum(np.exp(temp*norm_x), axis=1, keepdims=True)
 
-def load_model_wrapper(model_hdf5):
+def load_model_wrapper(args, model_hdf5):
     # read .h5 model
     custom_objects={"multinomial_nll":losses.multinomial_nll, "tf": tf}    
-    get_custom_objects().update(custom_objects)    
-    model=load_model(model_hdf5, compile=False)
+    get_custom_objects().update(custom_objects)
+    # get the strategy for multiGPU
+    from chrombpnet.helpers.misc import get_strategy
+    with get_strategy(args).scope():
+        model=load_model(model_hdf5, compile=False)
     print("got the model")
     model.summary()
     return model
@@ -125,7 +128,7 @@ def main(args):
 
 
     if args.chrombpnet_model_nb:
-        model_chrombpnet_nb = load_model_wrapper(model_hdf5=args.chrombpnet_model_nb)
+        model_chrombpnet_nb = load_model_wrapper(args, model_hdf5=args.chrombpnet_model_nb)
         inputlen = int(model_chrombpnet_nb.input_shape[1])
         outputlen = int(model_chrombpnet_nb.output_shape[0][1])
 
@@ -165,7 +168,7 @@ def main(args):
         	
 
     if args.chrombpnet_model:
-        model_chrombpnet = load_model_wrapper(model_hdf5=args.chrombpnet_model)
+        model_chrombpnet = load_model_wrapper(args, model_hdf5=args.chrombpnet_model)
         inputlen = int(model_chrombpnet.input_shape[1])
         outputlen = int(model_chrombpnet.output_shape[0][1])
 
@@ -205,7 +208,7 @@ def main(args):
         	
 
     if args.bias_model:
-        model_bias = load_model_wrapper(model_hdf5=args.bias_model)
+        model_bias = load_model_wrapper(args, model_hdf5=args.bias_model)
         inputlen = int(model_bias.input_shape[1])
         outputlen = int(model_bias.output_shape[0][1])
 

--- a/chrombpnet/evaluation/marginal_footprints/marginal_footprinting.py
+++ b/chrombpnet/evaluation/marginal_footprints/marginal_footprinting.py
@@ -26,7 +26,10 @@ def load_model_wrapper(args):
     # read .h5 model
     custom_objects={"multinomial_nll":losses.multinomial_nll, "tf": tf}    
     get_custom_objects().update(custom_objects)    
-    model=load_model(args.model_h5, compile=False)
+    # get the strategy for multiGPU
+    from chrombpnet.helpers.misc import get_strategy
+    with get_strategy(args).scope():
+	    model=load_model(args.model_h5, compile=False)
     print("got the model")
     model.summary()
     return model

--- a/chrombpnet/evaluation/variant_effect_prediction/snp_scoring.py
+++ b/chrombpnet/evaluation/variant_effect_prediction/snp_scoring.py
@@ -31,8 +31,11 @@ def softmax(x, temp=1):
 def load_model_wrapper(args):
     # read .h5 model
     custom_objects={"tf": tf, "multinomial_nll":losses.multinomial_nll}    
-    get_custom_objects().update(custom_objects)    
-    model=load_model(args.model_h5, compile=False)
+    get_custom_objects().update(custom_objects)
+    # get the strategy for multiGPU
+    from chrombpnet.helpers.misc import get_strategy
+    with get_strategy(args).scope():
+        model=load_model(args.model_h5, compile=False)
     print("model loaded succesfully")
     return model
 

--- a/chrombpnet/helpers/hyperparameters/find_chrombpnet_hyperparams.py
+++ b/chrombpnet/helpers/hyperparameters/find_chrombpnet_hyperparams.py
@@ -145,7 +145,7 @@ def main(args):
 
     # adjust bias model for training  - using train and validation set
     # the bias model might be trained on a difference read depth compared to the given data - so this step scales the bias model to account for that
-    bias_model = param_utils.load_model_wrapper(args.bias_model_path)
+    bias_model = param_utils.load_model_wrapper(args, args.bias_model_path)
     bias_model_scaled = adjust_bias_model_logcounts(bias_model, nonpeak_seqs[(nonpeak_cnts< upper_thresh) & (nonpeak_cnts>lower_thresh)], nonpeak_cnts[(nonpeak_cnts< upper_thresh) & (nonpeak_cnts>lower_thresh)])
     # save the new bias model
     bias_model_scaled.save("{}bias_model_scaled.h5".format(args.output_prefix))

--- a/chrombpnet/helpers/hyperparameters/param_utils.py
+++ b/chrombpnet/helpers/hyperparameters/param_utils.py
@@ -55,11 +55,14 @@ def get_seqs_cts(genome, bw, peaks_df, input_width=2114, output_width=1000):
         vals.append(bigwig_vals)
     return (np.sum(np.array(vals),axis=1), one_hot.dna_to_one_hot(seqs))
 
-def load_model_wrapper(model_h5):
+def load_model_wrapper(args, model_h5):
     # read .h5 model
     custom_objects={"tf": tf, "multinomial_nll":losses.multinomial_nll}    
     get_custom_objects().update(custom_objects)    
-    model=load_model(model_h5)
+    # get the strategy for multiGPU
+    from chrombpnet.helpers.misc import get_strategy
+    with get_strategy(args).scope():
+        model=load_model(model_h5)
     print("got the model")
     model.summary()
     return model

--- a/chrombpnet/helpers/misc.py
+++ b/chrombpnet/helpers/misc.py
@@ -1,0 +1,13 @@
+import tensorflow as tf
+
+def get_strategy(args):
+    # get tf strategy to either run on single, or multiple GPUs
+    if vars(args).get('multiGPU') and args.multiGPU:
+        # run the model in "data parallel" mode on multiple GPU devices (on one machine).
+        strategy = tf.distribute.MirroredStrategy()
+        print('Number of GPU devices: {}'.format(strategy.num_replicas_in_sync))
+    else:
+        strategy = tf.distribute.get_strategy()
+        print('Single GPU device')
+
+    return strategy

--- a/chrombpnet/parsers.py
+++ b/chrombpnet/parsers.py
@@ -75,6 +75,7 @@ def read_parser():
         	optional_train.add_argument('--bsort', required=False, default=False, action='store_true', help="In prpeprocess, by deafult we sort bam using unix sort but sometimes LC collate can cause issues, so this can be set to use betools sort which works well but is memory intensive..")
         	optional_train.add_argument('--tmpdir', required=False, default=None, type=str, help="temp dir for unix sort")
         	optional_train.add_argument('--no-st', required=False, default=False, action='store_true', help="Dont do streaming  and filtering in preprocessing (short chromosome contrigs not in reference fasta are not removed)")
+        	optional_train.add_argument('--multiGPU', default=False, action='store_true')
 
         	return required_train, optional_train
 

--- a/chrombpnet/pipelines.py
+++ b/chrombpnet/pipelines.py
@@ -170,19 +170,22 @@ def chrombpnet_qc(args):
 	else:
 		fpx = ""
 	
-	def load_model_wrapper(model_hdf5):
+	def load_model_wrapper(args, model_hdf5):
 		# read .h5 model
 		from tensorflow.keras.utils import get_custom_objects
 		from tensorflow.keras.models import load_model
 		import tensorflow as tf
 		import chrombpnet.training.utils.losses as losses
 		custom_objects={"multinomial_nll":losses.multinomial_nll, "tf": tf}    
-		get_custom_objects().update(custom_objects)    
-		model=load_model(model_hdf5)
+		get_custom_objects().update(custom_objects)
+		# get the strategy for multiGPU
+		from chrombpnet.helpers.misc import get_strategy
+		with get_strategy(args).scope():
+			model=load_model(model_hdf5)
 		model.summary()
 		return model
     
-	chrombpnet_md = load_model_wrapper(model_hdf5=args.chrombpnet_model)
+	chrombpnet_md = load_model_wrapper(args, model_hdf5=args.chrombpnet_model)
 	args.inputlen = int(chrombpnet_md.input_shape[1])
 	args.outputlen = int(chrombpnet_md.output_shape[0][1])
 	
@@ -384,19 +387,22 @@ def bias_model_qc(args):
 	else:
 		fpx = ""
 	
-	def load_model_wrapper(model_hdf5):
+	def load_model_wrapper(args, model_hdf5):
 		# read .h5 model
 		from tensorflow.keras.utils import get_custom_objects
 		from tensorflow.keras.models import load_model
 		import tensorflow as tf
 		import chrombpnet.training.utils.losses as losses
 		custom_objects={"multinomial_nll":losses.multinomial_nll, "tf": tf}    
-		get_custom_objects().update(custom_objects)    
-		model=load_model(model_hdf5)
+		get_custom_objects().update(custom_objects)
+		# get the strategy for multiGPU
+		from chrombpnet.helpers.misc import get_strategy
+		with get_strategy(args).scope():
+			model=load_model(model_hdf5)
 		model.summary()
 		return model
     
-	bias_md = load_model_wrapper(model_hdf5=args.bias_model)
+	bias_md = load_model_wrapper(args, model_hdf5=args.bias_model)
 	args.inputlen = int(bias_md.input_shape[1])
 	args.outputlen = int(bias_md.output_shape[0][1])
 	

--- a/chrombpnet/training/predict.py
+++ b/chrombpnet/training/predict.py
@@ -54,8 +54,11 @@ def write_predictions_h5py(output_prefix, profile, logcts, coords):
 def load_model_wrapper(args):
     # read .h5 model
     custom_objects={"tf": tf, "multinomial_nll":losses.multinomial_nll}    
-    get_custom_objects().update(custom_objects)    
-    model=load_model(args.model_h5, compile=False)
+    get_custom_objects().update(custom_objects)
+    # get the strategy for multiGPU
+    from chrombpnet.helpers.misc import get_strategy
+    with get_strategy(args).scope():
+        model=load_model(args.model_h5, compile=False)
     print("got the model")
     #model.summary()
     return model

--- a/chrombpnet/training/train.py
+++ b/chrombpnet/training/train.py
@@ -20,8 +20,11 @@ def get_model(args, parameters):
     Look at .py models in src/training/models/ for examples. I will try to provide a dummy model as example here - for later.
     The files should have the following two functions - getModelGivenModelOptionsAndWeightInits and save_model_without_bias
     """
-    architecture_module=importlib.machinery.SourceFileLoader('',args.architecture_from_file).load_module()
-    model=architecture_module.getModelGivenModelOptionsAndWeightInits(args, parameters)
+    # get the strategy for multiGPU
+    from chrombpnet.helpers.misc import get_strategy
+    with get_strategy(args).scope():
+        architecture_module=importlib.machinery.SourceFileLoader('',args.architecture_from_file).load_module()
+        model=architecture_module.getModelGivenModelOptionsAndWeightInits(args, parameters)
     print("got the model")
     return model, architecture_module
 


### PR DESCRIPTION
Hi Anusri, here is my code to parallelize on multiple GPUs if they are available on the system. I have 4 on my system so it helps a lot.

I add a --multiGPU flag to turn this on. Whenever a model is loaded, I wrap with a tf strategy, see helpers/misc.py. Then tensorflow will automatically parallelize the work on multiple GPUs with their "MirroredStrategy" which loads the same model on all GPUs, and runs the training or prediction in parallel.

I have put this wrapping in multiple places wherever a model is loaded. But if you prefer, the most important 2 spots in terms of total time saved are in training/predict.py and training/train.py. So you could just do it in those 2 places if you want to simplify the patch. (LMK if it's helpful for me to make a simplfied patch that does that.)

Unfortunately I couldn't get shap to use multiple GPUs even if you wrap it like this, so that (interpret.py) still takes a lot of time in a full run of the pipeline. Maybe they will update in the future, or maybe I will figure it out.

Thanks for releasing your awesome code!