### PR TITLE
Allowed pipeline (bias and train) to use defined +/- shifts

### DIFF
--- a/chrombpnet/parsers.py
+++ b/chrombpnet/parsers.py
@@ -57,8 +57,8 @@ def read_parser():
         	required_train.add_argument("-fl", "--chr-fold-path", type=str, required=True, help="Fold information - dictionary with test,valid and train keys and values with corresponding chromosomes")
  
         	optional_train.add_argument("-oth", "--outlier-threshold", type=float, default=0.9999, help="threshold to use to filter outlies")
-        	#optional_train.add_argument('-ps', '--plus-shift', type=int, default=None, help="Plus strand shift applied to reads. Estimated if not specified")
-        	#optional_train.add_argument('-ms', '--minus-shift', type=int, default=None, help="Minus strand shift applied to reads. Estimated if not specified")
+        	optional_train.add_argument('-ps', '--plus-shift', type=int, default=None, help="Plus strand shift applied to reads. Estimated if not specified")
+        	optional_train.add_argument('-ms', '--minus-shift', type=int, default=None, help="Minus strand shift applied to reads. Estimated if not specified")
         	optional_train.add_argument('--ATAC-ref-path', type=str, default=None, help="Path to ATAC reference motifs (ATAC.ref.motifs.txt used by default)")
         	optional_train.add_argument('--DNASE-ref-path', type=str, default=None, help="Path to DNASE reference motifs (DNASE.ref.motifs.txt used by default)")
         	optional_train.add_argument('--num-samples', type=int, default=10000, help="Number of reads to sample from BAM/fragment/tagAlign file for shift estimation")

--- a/chrombpnet/pipelines.py
+++ b/chrombpnet/pipelines.py
@@ -16,8 +16,6 @@ def chrombpnet_train_pipeline(args):
 	# Shift bam and convert to bigwig
 	import chrombpnet.helpers.preprocessing.reads_to_bigwig as reads_to_bigwig	
 	args.output_prefix = os.path.join(args.output_dir,"auxiliary/{}data".format(fpx))
-	args.plus_shift = None
-	args.minus_shift = None
 	reads_to_bigwig.main(args)
 	
 	# QC bigwig
@@ -273,8 +271,6 @@ def train_bias_pipeline(args):
 	# Shift bam and convert to bigwig
 	import chrombpnet.helpers.preprocessing.reads_to_bigwig as reads_to_bigwig	
 	args.output_prefix = os.path.join(args.output_dir,"auxiliary/{}data".format(fpx))
-	args.plus_shift = None
-	args.minus_shift = None
 	reads_to_bigwig.main(args)
 	
 	# QC bigwig

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ config = {
     'include_package_data': True,
     'description': 'chrombpnet predicts chromatin accessibility from sequence',
     'download_url': 'https://github.com/kundajelab/chrombpnet',
-    'version': '1.0.1',
+    'version': '1.0.2',
     'packages': find_packages(),
     'python_requires': '>=3.8',
     'install_requires': install_requires,


### PR DESCRIPTION
Current version (`1.0.1`) forces the pipeline (both bias and regular training) to always compute auto-shift detection.
Users might want to skip this step as in some corner cases the detection might fail even when there is no real shift. In my case for example it correctly finds a shift of +0/-0 in two of the three example motifs used, and in one it finds +1/-0, resulting in an error. 
I've made `bias` and `train` correctly accept the parameters `--plus-shift` and `--minus-shift` which will be passed down to `reads_to_bigwig.py`